### PR TITLE
Safari doesn’t support OPFS createWritable method

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
   "scripts": {
     "dev": "vite",
     "build": "rm -r -f ./dist && tsc && vite build",
+    "prepare": "npm run build",
     "preview": "vite preview",
     "format": "npx @biomejs/biome format --write ./src",
     "test": "npx playwright test --project=chromium"

--- a/src/opfs.ts
+++ b/src/opfs.ts
@@ -9,9 +9,25 @@ export async function writeBlob(url: string, blob: Blob): Promise<void> {
 
 		const path = url.split('/').at(-1)!;
 		const file = await dir.getFileHandle(path, { create: true });
-		const writable = await file.createWritable();
-		await writable.write(blob);
-		await writable.close();
+		if (file.createWritable) {
+			const writable = await file.createWritable();
+			await writable.write(blob);
+			await writable.close();
+		} else if (self.WorkerGlobalScope) {
+			console.log(
+				'createWritable not supported, trying syncronous API with createSyncAccessHandle as we are a worker',
+			);
+			// use the synchronous write API to write to the file. Only works in web workers
+			const writer = await file.createSyncAccessHandle();
+			writer.write(await blob.arrayBuffer());
+			writer.close();
+		} else {
+			console.error(
+				"Cannot write to OPFS file using createWritable and we are not a worker, so can't use createSyncAccessHandle",
+			);
+			// Remove the empty file
+			await dir.removeEntry(path);
+		}
 	} catch (e) {
 		console.error(e);
 	}


### PR DESCRIPTION
Instead we have to use a Synchronous write method, which is only available if we are running in a web worker.

If we are not running in a worker, put a warning to console, and don’t leave behind an empty file.